### PR TITLE
Make ReverseImageSearch non instantiable and final

### DIFF
--- a/src/main/java/it/polpetta/libris/ReverseImageSearch.java
+++ b/src/main/java/it/polpetta/libris/ReverseImageSearch.java
@@ -5,7 +5,9 @@ import it.polpetta.libris.google.GoogleAbstractFactory;
 /**
  * Created by davide on 28/04/17.
  */
-public class ReverseImageSearch {
+public final class ReverseImageSearch {
+
+    private ReverseImageSearch(){}
 
     public static IAbstractFactoryReverseSearchProvider getGoogleServices() {
         return new GoogleAbstractFactory();


### PR DESCRIPTION
Non dovrebbe cambiare nulla, e' solo per rendere la classe principale non istanziabile e non estendibile.

Questa PR e' legata a #2 